### PR TITLE
Fix IllegalStateExceptions by not reusing streams.

### DIFF
--- a/README
+++ b/README
@@ -12,8 +12,6 @@ Check included LICENSE file.
 
 - MAC ClassLoader bug known in 2017 versions of IntelliJ. Execution unaffected, but red output indicating errors can be seen in Terminal.
 
-- add() unit test succeeds, but right before termination 4 IllegalStateExceptions are thrown.
-
 - Javadoc contains some tags that might not be supported.
 
 **MATLAB demo on matrix storage:**

--- a/src/edu/umd/cs/datastructures/bags/testcases/BagTests.java
+++ b/src/edu/umd/cs/datastructures/bags/testcases/BagTests.java
@@ -57,7 +57,6 @@ public class BagTests {
     @org.junit.Test
     public void add() throws Exception {
         try {
-        	
             testAdditions(thousand, staticBag);
             thousand = IntStream.rangeClosed(1, 1000);
             testAdditions(thousand, shuffledBag);
@@ -88,7 +87,6 @@ public class BagTests {
         } catch(Exception e){
             System.err.println("Caught an " + e.getClass().getSimpleName());
         }
-
     }
 
     @org.junit.Test

--- a/src/edu/umd/cs/datastructures/bags/testcases/BagTests.java
+++ b/src/edu/umd/cs/datastructures/bags/testcases/BagTests.java
@@ -57,9 +57,11 @@ public class BagTests {
     @org.junit.Test
     public void add() throws Exception {
         try {
-
+        	
             testAdditions(thousand, staticBag);
+            thousand = IntStream.rangeClosed(1, 1000);
             testAdditions(thousand, shuffledBag);
+            thousand = IntStream.rangeClosed(1, 1000);
             testAdditions(thousand, randomAccessBag);
 
             // Clear and reset the bags pretty quick
@@ -67,7 +69,9 @@ public class BagTests {
             setUp();
 
             testAdditions(tenthousand, staticBag);
+            tenthousand = IntStream.rangeClosed(1, 10000);
             testAdditions(tenthousand, shuffledBag);
+            tenthousand = IntStream.rangeClosed(1, 10000);
             testAdditions(tenthousand, randomAccessBag);
         }
         catch(Exception e){


### PR DESCRIPTION
Technically the test should not have passed, but the exception was being caught in the test. But that doesnt really matter.

~~There is that extra whitespace I added, but I dont feel like making another commit.~~ I resisted the urge to run my eclipse formatter on all the code.

Hope this helps!